### PR TITLE
Fix transformations from dashcase to other cases.

### DIFF
--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -111,10 +111,11 @@ function! s:mixedcase(word)
 endfunction
 
 function! s:camelcase(word)
-  if a:word !~# '_' && a:word =~# '\l'
-    return substitute(a:word,'^.','\l&','')
+  let word = substitute(a:word, '-', '_', 'g')
+  if word !~# '_' && word =~# '\l'
+    return substitute(word,'^.','\l&','')
   else
-    return substitute(a:word,'\C\(_\)\=\(.\)','\=submatch(1)==""?tolower(submatch(2)) : toupper(submatch(2))','g')
+    return substitute(word,'\C\(_\)\=\(.\)','\=submatch(1)==""?tolower(submatch(2)) : toupper(submatch(2))','g')
   endif
 endfunction
 


### PR DESCRIPTION
I found a bug in Coercions which prevents it from converting a dashcase identifier to other cases. Specifically, the code uses the w motion to yank the identifiers for parsing but this breaks with dashcase because w doesn't traverse dashes (unlike underscores, which is why snakecase doesn't have this problem). 

I've changed the motions to W in three places. It seems to work but I'm not 100% this is correct. Please check before pulling. If the patch is not correct, I'll be happy to update it if you need me to. :-)

Update: The dash -> mixed/camel transformations were still left unhandled by the above mentioned changes so I added another commit which addresses this. Since mixedcase calls camelcase, the latter was the only function that needed changing.
