### PR TITLE
Add synonym 'U' for coercion to uppercase

### DIFF
--- a/doc/abolish.txt
+++ b/doc/abolish.txt
@@ -154,6 +154,7 @@ characters:
   _: snake_case
   s: snake_case
   u: SNAKE_UPPERCASE
+  U: SNAKE_UPPERCASE
   -: dash-case (not reversible)
 
 For example, cru on a lowercase word is a slightly easier to type equivalent

--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -554,6 +554,7 @@ call extend(Abolish.Coercions, {
       \ 's': Abolish.snakecase,
       \ '_': Abolish.snakecase,
       \ 'u': Abolish.uppercase,
+      \ 'U': Abolish.uppercase,
       \ '-': Abolish.dashcase,
       \ "function missing": s:function("s:unknown_coercion")
       \}, "keep")


### PR DESCRIPTION
I'd like to propose adding 'U' as a synonym for 'u' for coercion to upper case.

A proficient Vim user has memorized "U" as "convert to upper case" and "u" as "convert to lower case". He or she uses these routinely in commands like, say, "gUiw" or "veu".

Speaking more personally, I just feel it goes against my intuition to type "cru" instead of "crU" to coerce to upper case. I realize lower case "u" is more efficient for my fingers, but it is less efficient for my brain. The tipping point was when I hadn't used coercion for a while and used the upper case variant with nothing happening.
