### PR TITLE
Change :Subvert default range to current line

### DIFF
--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -606,10 +606,10 @@ nmap cr  <Plug>Coerce
 
 command! -nargs=+ -bang -bar -range=0 -complete=custom,s:Complete Abolish
       \ :exec s:dispatcher(<bang>0,<line1>,<line2>,<count>,[<f-args>])
-command! -nargs=1 -bang -bar -range=0 -complete=custom,s:SubComplete Subvert
+command! -nargs=1 -bang -bar -range -complete=custom,s:SubComplete Subvert
       \ :exec s:subvert_dispatcher(<bang>0,<line1>,<line2>,<count>,<q-args>)
 if exists(':S') != 2
-  command -nargs=1 -bang -bar -range=0 -complete=custom,s:SubComplete S
+  command -nargs=1 -bang -bar -range -complete=custom,s:SubComplete S
         \ :exec s:subvert_dispatcher(<bang>0,<line1>,<line2>,<count>,<q-args>)
 endif
 


### PR DESCRIPTION
While Vim's substitute command works on the current line when no range is specified:

``` vim
:s/foo/bar
```

I noticed that the subvert command does nothing when called in a similar fashion:

``` vim
:S/foo/bar
```

This pull request changes the `:Subvert` and `:S` commands to use the current line by default.
