### PR TITLE
Escape ampersand

### DIFF
--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -322,7 +322,7 @@ endfunction
 " Searching {{{1
 
 function! s:subesc(pattern)
-  return substitute(a:pattern,'[][\\/.*~%()]','\\&','g')
+  return substitute(a:pattern,'[][\\/.*~%()&]','\\&','g')
 endfunction
 
 function! s:sort(a,b)


### PR DESCRIPTION
I often need to do a search and replace such like this:

```
%S/Tom {&,&amp;} Jerry/Ben {&,&amp;} Jerry/g
```

In order to do this, ampersand needs to be escaped...
