### PR TITLE
Adds support for S//sub/ syntax.

### DIFF
--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -427,7 +427,11 @@ endfunction
 
 function! s:substitute_command(cmd,bad,good,flags)
   let opts = s:normalize_options(a:flags)
-  let dict = s:create_dictionary(a:bad,a:good,opts)
+  let bad_or_search = a:bad
+  if empty(bad_or_search)
+    let bad_or_search = @/
+  endif
+  let dict = s:create_dictionary(bad_or_search,a:good,opts)
   let lhs = s:pattern(dict,opts.boundaries)
   let g:abolish_last_dict = dict
   return a:cmd.'/'.lhs.'/\=Abolished()'."/".opts.flags


### PR DESCRIPTION
I'm not terribly sure what the ideal for modifying the @/ register is - I like that abolish modifies the register as I can then use n/N to navigate around a file. This fix does that, which is fine the first time...

But multiple calls to S//sub/ to create nested ugly search strings to appear in @/...