### PR TITLE
Guard mappings with an option.

### DIFF
--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -603,7 +603,9 @@ nnoremap <silent> <Plug>Coerce :<C-U>call <SID>coerce(nr2char(getchar()))<CR>
 
 " }}}1
 
-nmap cr  <Plug>Coerce
+if !exists("g:abolish_no_mappings") || ! g:abolish_no_mappings
+  nmap cr  <Plug>Coerce
+endif
 
 command! -nargs=+ -bang -bar -range=0 -complete=custom,s:Complete Abolish
       \ :exec s:dispatcher(<bang>0,<line1>,<line2>,<count>,[<f-args>])


### PR DESCRIPTION
A `g:surround_no_insert_mappings` option lets users avoid unwanted clobbering of mappings and makes it possible for them to define their own:

```vimL
let g:abolish_no_mappings = 1
nmap lr <Plug>Coerce
```

This could be a fix for #44.

The option is modelled after [vim-surround](https://github.com/tpope/vim-surround/blob/master/plugin/surround.vim#L578-596) and just like it it is not documented.