### PR TITLE
Add a space-case coercion

### DIFF
--- a/doc/abolish.txt
+++ b/doc/abolish.txt
@@ -149,15 +149,16 @@ Abolish's case mutating algorithms can be applied to the word under the cursor
 using the cr mapping (mnemonic: CoeRce) followed by one of the following
 characters:
 
-  c: camelCase
-  m: MixedCase
-  _: snake_case
-  s: snake_case
-  u: SNAKE_UPPERCASE
-  U: SNAKE_UPPERCASE
-  -: dash-case (not usually reversible; see |abolish-coercion-reversible|)
-  k: kebab-case (not usually reversible; see |abolish-coercion-reversible|)
-  .: dot.case (not usually reversible; see |abolish-coercion-reversible|)
+  c:       camelCase
+  m:       MixedCase
+  _:       snake_case
+  s:       snake_case
+  u:       SNAKE_UPPERCASE
+  U:       SNAKE_UPPERCASE
+  -:       dash-case (not usually reversible; see |abolish-coercion-reversible|)
+  k:       kebab-case (not usually reversible; see |abolish-coercion-reversible|)
+  .:       dot.case (not usually reversible; see |abolish-coercion-reversible|)
+  <space>: space case (not usually reversible; see |abolish-coercion-reversible|)
 
 For example, cru on a lowercase word is a slightly easier to type equivalent
 to gUiw.

--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -134,6 +134,10 @@ function! s:dashcase(word)
   return substitute(s:snakecase(a:word),'_','-','g')
 endfunction
 
+function! s:spacecase(word)
+  return substitute(s:snakecase(a:word),'_',' ','g')
+endfunction
+
 function! s:dotcase(word)
   return substitute(s:snakecase(a:word),'_','.','g')
 endfunction
@@ -144,7 +148,8 @@ call extend(Abolish, {
       \ 'snakecase':  s:function('s:snakecase'),
       \ 'uppercase':  s:function('s:uppercase'),
       \ 'dashcase':   s:function('s:dashcase'),
-      \ 'dotcase':    s:function('s:dotcase')
+      \ 'dotcase':    s:function('s:dotcase'),
+      \ 'spacecase':  s:function('s:spacecase')
       \ }, 'keep')
 
 function! s:create_dictionary(lhs,rhs,opts)
@@ -563,6 +568,7 @@ call extend(Abolish.Coercions, {
       \ '-': Abolish.dashcase,
       \ 'k': Abolish.dashcase,
       \ '.': Abolish.dotcase,
+      \ ' ': Abolish.spacecase,
       \ "function missing": s:function("s:unknown_coercion")
       \}, "keep")
 


### PR DESCRIPTION
Allows transforming `isAKeyWord` or `is_a_key_word` or `is-a-key-word`
into `is a key word`. Not reversible since spaces break up keywords, and
only a maniac would include spaces in `iskeyword`.

Mapping uses `+` by analogy with URL encoding because I couldn't think
of something better.