### PR TITLE
Remove repeat.vim reference from README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -120,8 +120,7 @@ Want to turn `fooBar` into `foo_bar`?  Press `crs` (coerce to
 snake\_case).  MixedCase (`crm`), camelCase (`crc`), snake\_case
 (`crs`), UPPER\_CASE (`cru`), dash-case (`cr-`), dot.case (`cr.`),
 space case (`cr<space>`), and Title Case (`crt`) are all just 3
-keystrokes away.  These commands support
-[repeat.vim](https://github.com/tpope/vim-repeat).
+keystrokes away.
 
 ## Installation
 


### PR DESCRIPTION
Abolish no longer requires [repeat.vim](https://github.com/tpope/vim-repeat).