### PR TITLE
Fix invalid sid expression

### DIFF
--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -622,7 +622,7 @@ endfunction
 
 nnoremap <expr> <Plug>(abolish-coerce) <SID>coerce(nr2char(getchar()))
 nnoremap <expr> <Plug>(abolish-coerce) <SID>coerce(nr2char(getchar()))
-nnoremap <expr> <plug>(abolish-coerce-word) <sid>coerce(nr2char(getchar())).'iw'
+nnoremap <expr> <plug>(abolish-coerce-word) <SID>coerce(nr2char(getchar())).'iw'
 
 " }}}1
 


### PR DESCRIPTION
vim-abolish plugin cause this error in both when using coercion
```
E120: Using <SID> not in a script context: <sid>coerce                                                                      
E15: Invalid expression: <sid>coerce(nr2char(getchar())).'iw'
```
I use **VIM 8.1** and **NVIM v0.3.4** This PR fixes bug