### PR TITLE
Allow escaped delimiter in substitution string

### DIFF
--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -284,7 +284,7 @@ function! s:parse_subvert(bang,line1,line2,count,args)
   else
     let args = a:args
   endif
-  let separator = matchstr(args,'^.')
+  let separator = '\v((\\)@<!(\\\\)*\\)@<!' . matchstr(args,'^.')
   let split = split(args,separator,1)[1:]
   if a:count || split == [""]
     return s:parse_substitute(a:bang,a:line1,a:line2,a:count,split)


### PR DESCRIPTION
Allow escaped delimiter in substitution string

Patterns with escaped delimiters result in an uncaught exception:

    :%S/\\/\//g
    Error detected while processing function <SNR>15_subvert_dispatcher[2]..<SNR>15_parse_subvert[9]..<SNR>15_parse_substitute[11]..<SNR>15_throw:
    line    2:
    E605: Exception not caught: Abolish: E488: Trailing characters
    Press ENTER or type command to continue

This is due to the way s:parse_subvert deconstructs the substitution
string:

    let separator = matchstr(args,'^.')
    let split = split(args,separator,1)[1:]

This correctly determines that '/' is the separator character, but the
subsequent `split()` doesn't take into account the possibility that
there might be escaped '/' characters in the pattern that do not delimit
the different parts of the regex. The result array thus ends up with
more elements than expected, which eventually causes the command to fail
due to it thinking that there are too many delimiters.

In this case, `/\\/\//g` gets split into `['', '\\', '\', '', 'g']`
instead of the intended `['', '\\', '\/', 'g']`.

This commit attempts to fix the issue by changing the split regex so it
only splits on delimiters not preceded by an odd number of backslashes.

The regex blob that gets prepended to the separator is a bit of a mess:

    '\v((\\)@<!(\\\\)*\\)@<!'
        ^-----^^-------^ ^
           |       |     |
           |       |     -- Not preceded by
           |       -------- a                    odd number of '\'
           ----------------   consecutive/greedy

"Consecutive/greedy" is not the greatest description, but I'm not sure
what a better phrase might be. The intent of that section of the regex
is to ensure all backslashes in the group get counted, as opposed to
only the backslash before the separator making a difference.

For a more concrete example, if the part of the regex corresponding to
"consecutive/greedy" was removed, you get:

    split('s/\//b/g', '\v((\\\\)*\\)@<!/', 1)    -> ['s', '\/', 'b', 'g']
    split('s/\\//b/g', '\v((\\\\)*\\)@<!/', 1)   -> ['s', '\\/', 'b', 'g']
    split('s/\\\//b/g', '\v((\\\\)*\\)@<!/', 1)  -> ['s', '\\\/', 'b', 'g']
    split('s/\\\\//b/g', '\v((\\\\)*\\)@<!/', 1) -> ['s', '\\\\/', 'b', 'g']

etc., since the number of backslashes before the rightmost preceding
backslash won't make a difference when determining where to split as all
the pattern cares about is that first preceding backslash. With the
extra bit, you get:

    split('s/\//b/g', '\v((\\)@<!(\\\\)*\\)@<!/', 1)    -> ['s', '\/', 'b', 'g']
    split('s/\\//b/g', '\v((\\)@<!(\\\\)*\\)@<!/', 1)   -> ['s', '\\', '', 'b', 'g']
    split('s/\\\//b/g', '\v((\\)@<!(\\\\)*\\)@<!/', 1)  -> ['s', '\\\/', 'b', 'g']
    split('s/\\\\//b/g', '\v((\\)@<!(\\\\)*\\)@<!/', 1) -> ['s', '\\\\', '', 'b', 'g']

Users can also pick a different delimiter character, but I'm not sure
how widely known that feature is. At the very least, this brings the
behavior of :Subvert closer to that of :substitute.

That unlimited negative lookbehind could result in performance issues
for larger documents. Limiting the lookbehind as suggested in [0] could
be one way to reduce the potential performance hit while still
addressing most of the backslash cases a user is likely to run into.
There might be a better regex which gets the job done with less
complexity, too.

[0]: https://www.reddit.com/r/vim/comments/8ggdqn/undocumented_tips_make_your_vim_1020x_times_faster/dybhapy/
