### PR TITLE
Changed to use getcurpos to get the value for begin, so that it restores curswant

### DIFF
--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -588,6 +588,7 @@ function! s:coerce(type) abort
     let regbody = getreg('"')
     let regtype = getregtype('"')
     let c = v:count1
+    let begin = getcurpos()
     while c > 0
       let c -= 1
       if a:type ==# 'line'
@@ -600,9 +601,6 @@ function! s:coerce(type) abort
       silent exe 'normal!' move.'y'
       let word = @@
       let @@ = s:send(g:Abolish.Coercions,s:transformation,word)
-      if !exists('begin')
-        let begin = getpos("'[")
-      endif
       if word !=# @@
         let changed = 1
         exe 'normal!' move.'p'


### PR DESCRIPTION
You can repro the bug that this fixes by just running `crt` on a word, and then hitting `j`.  What happens in this case is the cursor jumps to a column that matches the end of the replacement that was made.  It should instead retain its current column.  This is fixed by using `getcurpos`