### PR TITLE
FIX: Duplicate nmap should be vmap instead

### DIFF
--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -616,7 +616,7 @@ function! s:coerce(type) abort
 endfunction
 
 nnoremap <expr> <Plug>(abolish-coerce) <SID>coerce(nr2char(getchar()))
-nnoremap <expr> <Plug>(abolish-coerce) <SID>coerce(nr2char(getchar()))
+vnoremap <expr> <Plug>(abolish-coerce) <SID>coerce(nr2char(getchar()))
 nnoremap <expr> <plug>(abolish-coerce-word) <SID>coerce(nr2char(getchar())).'iw'
 
 " }}}1


### PR DESCRIPTION
Presumably a simply copy-and-paste mistake.