### PR TITLE
Add support for ripgrep and ag (Silver Searcher)

### DIFF
--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -399,6 +399,8 @@ function! s:grep_command(args,bang,flags,word)
   let dict = s:create_dictionary(a:word,"",opts)
   if &grepprg == "internal"
     let lhs = "'".s:pattern(dict,opts.boundaries)."'"
+  elseif &grepprg =~ "^rg"
+    let lhs = "'".s:egrep_pattern(dict,opts.boundaries)."'"
   else
     let lhs = "-E '".s:egrep_pattern(dict,opts.boundaries)."'"
   endif

--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -399,7 +399,7 @@ function! s:grep_command(args,bang,flags,word)
   let dict = s:create_dictionary(a:word,"",opts)
   if &grepprg == "internal"
     let lhs = "'".s:pattern(dict,opts.boundaries)."'"
-  elseif &grepprg =~ "^rg"
+  elseif &grepprg =~# '^rg\|^ag'
     let lhs = "'".s:egrep_pattern(dict,opts.boundaries)."'"
   else
     let lhs = "-E '".s:egrep_pattern(dict,opts.boundaries)."'"


### PR DESCRIPTION
Ripgrep uses Perl-like regex syntax by default (https://github.com/BurntSushi/ripgrep/blob/master/doc/rg.1.txt.tpl#L61), and the -E flag specifies encoding, so the default grep flags cause it to fail.