### PR TITLE
Remove duplicate Coercion keymap from README list

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -117,10 +117,9 @@ There's also a variant for searching and a variant for grepping.
 ## Coercion
 
 Want to turn `fooBar` into `foo_bar`?  Press `crs` (coerce to
-snake\_case).  MixedCase (`crm`), camelCase (`crc`), snake\_case
-(`crs`), UPPER\_CASE (`cru`), dash-case (`cr-`), dot.case (`cr.`),
-space case (`cr<space>`), and Title Case (`crt`) are all just 3
-keystrokes away.
+snake\_case).  MixedCase (`crm`), camelCase (`crc`), UPPER\_CASE (`cru`), 
+dash-case (`cr-`), dot.case (`cr.`), space case (`cr<space>`), and 
+Title Case (`crt`) are all just 3 keystrokes away.
 
 ## Installation
 


### PR DESCRIPTION
In case it was unintentional, the "coerce to snake_case" keymap is listed twice in the README. Great plugin, as usual!