### PR TITLE
Remove crt reference from README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -118,8 +118,8 @@ There's also a variant for searching and a variant for grepping.
 
 Want to turn `fooBar` into `foo_bar`?  Press `crs` (coerce to
 snake\_case).  MixedCase (`crm`), camelCase (`crc`), UPPER\_CASE (`cru`), 
-dash-case (`cr-`), dot.case (`cr.`), space case (`cr<space>`), and 
-Title Case (`crt`) are all just 3 keystrokes away.
+dash-case (`cr-`), dot.case (`cr.`), and space case (`cr<space>`) are all
+just 3 keystrokes away.
 
 ## Installation
 


### PR DESCRIPTION
Removed README reference to crt which was removed in https://github.com/tpope/vim-abolish/commit/e5f0c592bc54bb8e3d6acc964a9db9f4037cbbf9.

It appears there are no references to crt in the vim docs.