### PR TITLE
Add $ to find_command regex

### DIFF
--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -377,7 +377,7 @@ function! s:find_command(cmd,flags,word)
   " beginning of the line, and we can't use position flags (e.g., /foo/e).
   " If we use :norm /pattern, we leave ourselves vulnerable to "press enter"
   " prompts (even with :silent).
-  let cmd = (a:cmd =~ '[?!]' ? '?' : '/')
+  let cmd = (a:cmd =~ '[?!]$' ? '?' : '/')
   let @/ = s:pattern(dict,opts.boundaries)
   if opts.flags == "" || !search(@/,'n')
     return "norm! ".cmd."\<CR>"


### PR DESCRIPTION
The regex [?!], used to determined whether to use ? or / for searching, gave false positives for ! while using the :S or :Suvbert commands because of the regex \v((\\)@<!(\\\\)*\\)@<! used as separator on parse_subvert.