### PR TITLE
Support spaces and dots when doing coercions

### DIFF
--- a/plugin/abolish.vim
+++ b/plugin/abolish.vim
@@ -109,7 +109,7 @@ function! s:mixedcase(word)
 endfunction
 
 function! s:camelcase(word)
-  let word = substitute(a:word, '-', '_', 'g')
+  let word = substitute(a:word, '[ .-]', '_', 'g')
   if word !~# '_' && word =~# '\l'
     return substitute(word,'^.','\l&','')
   else
@@ -121,7 +121,7 @@ function! s:snakecase(word)
   let word = substitute(a:word,'::','/','g')
   let word = substitute(word,'\(\u\+\)\(\u\l\)','\1_\2','g')
   let word = substitute(word,'\(\l\|\d\)\(\u\)','\1_\2','g')
-  let word = substitute(word,'[.-]','_','g')
+  let word = substitute(word,'[ .-]','_','g')
   let word = tolower(word)
   return word
 endfunction


### PR DESCRIPTION
Fixes the cases listed in https://github.com/tpope/vim-abolish/issues/123

Saw the commit comments [here](https://github.com/tpope/vim-abolish/commit/8fe5966961fc047f7f93b4158a418e54d1c205ff) and [here](https://github.com/tpope/vim-abolish/commit/e5f0c592bc54bb8e3d6acc964a9db9f4037cbbf9), so it's up to you whether this PR fits the design goal.  I think that dot-coercions should be included since `cr.` is officially documented.